### PR TITLE
Revert "Return `Promise<void>` from `Turbo.visit` (#650)"

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -8,7 +8,7 @@ import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
-  allowsVisitingLocation(location: URL, options: Partial<VisitOptions>): boolean
+  allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>): Promise<void>
   notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
@@ -24,7 +24,7 @@ export class Navigator {
   }
 
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
-    if (this.delegate.allowsVisitingLocation(location, options)) {
+    if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
         return this.delegate.visitProposedToLocation(location, options)
       } else {

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -9,7 +9,7 @@ import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
   allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
-  visitProposedToLocation(location: URL, options: Partial<VisitOptions>): Promise<void>
+  visitProposedToLocation(location: URL, options: Partial<VisitOptions>): void
   notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
 
@@ -26,14 +26,10 @@ export class Navigator {
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
     if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
-        return this.delegate.visitProposedToLocation(location, options)
+        this.delegate.visitProposedToLocation(location, options)
       } else {
         window.location.href = location.toString()
-
-        return Promise.resolve()
       }
-    } else {
-      return Promise.reject()
     }
   }
 
@@ -45,8 +41,6 @@ export class Navigator {
       ...options,
     })
     this.currentVisit.start()
-
-    return this.currentVisit.promise
   }
 
   submitForm(form: HTMLFormElement, submitter?: HTMLElement) {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -5,7 +5,7 @@ import { History } from "./history"
 import { getAnchor } from "../url"
 import { Snapshot } from "../snapshot"
 import { PageSnapshot } from "./page_snapshot"
-import { Action, ResolvingFunctions } from "../types"
+import { Action } from "../types"
 import { getHistoryMethodForAction, uuid } from "../../util"
 import { PageView } from "./page_view"
 import { StreamMessage } from "../streams/stream_message"
@@ -85,9 +85,6 @@ export class Visit implements FetchRequestDelegate {
   readonly visitCachedSnapshot: (snapshot: Snapshot) => void
   readonly willRender: boolean
   readonly updateHistory: boolean
-  readonly promise: Promise<void>
-
-  private resolvingFunctions!: ResolvingFunctions<void>
 
   followedRedirect = false
   frame?: number
@@ -113,7 +110,6 @@ export class Visit implements FetchRequestDelegate {
     this.delegate = delegate
     this.location = location
     this.restorationIdentifier = restorationIdentifier || uuid()
-    this.promise = new Promise((resolve, reject) => (this.resolvingFunctions = { resolve, reject }))
 
     const {
       action,
@@ -180,8 +176,6 @@ export class Visit implements FetchRequestDelegate {
       }
       this.cancelRender()
       this.state = VisitState.canceled
-
-      this.resolvingFunctions.reject()
     }
   }
 
@@ -195,8 +189,6 @@ export class Visit implements FetchRequestDelegate {
         this.adapter.visitCompleted(this)
         this.delegate.visitCompleted(this)
       }
-
-      this.resolvingFunctions.resolve()
     }
   }
 
@@ -204,8 +196,6 @@ export class Visit implements FetchRequestDelegate {
     if (this.state == VisitState.started) {
       this.state = VisitState.failed
       this.adapter.visitFailed(this)
-
-      this.resolvingFunctions.reject()
     }
   }
 

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -51,7 +51,6 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean
-  initiator: Element
 }
 
 const defaultOptions: VisitOptions = {
@@ -62,7 +61,6 @@ const defaultOptions: VisitOptions = {
   updateHistory: true,
   shouldCacheSnapshot: true,
   acceptsStreamResponse: false,
-  initiator: document.documentElement,
 }
 
 export type VisitResponse = {
@@ -88,7 +86,6 @@ export class Visit implements FetchRequestDelegate {
   readonly willRender: boolean
   readonly updateHistory: boolean
   readonly promise: Promise<void>
-  readonly initiator: Element
 
   private resolvingFunctions!: ResolvingFunctions<void>
 
@@ -129,7 +126,6 @@ export class Visit implements FetchRequestDelegate {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
-      initiator,
     } = {
       ...defaultOptions,
       ...options,
@@ -146,7 +142,6 @@ export class Visit implements FetchRequestDelegate {
     this.scrolled = !willRender
     this.shouldCacheSnapshot = shouldCacheSnapshot
     this.acceptsStreamResponse = acceptsStreamResponse
-    this.initiator = initiator
   }
 
   get adapter() {
@@ -227,7 +222,7 @@ export class Visit implements FetchRequestDelegate {
     if (this.hasPreloadedResponse()) {
       this.simulateRequest()
     } else if (this.shouldIssueRequest() && !this.request) {
-      this.request = new FetchRequest(this, FetchMethod.get, this.location, undefined, this.initiator)
+      this.request = new FetchRequest(this, FetchMethod.get, this.location)
       this.request.perform()
     }
   }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -64,8 +64,8 @@ export function registerAdapter(adapter: Adapter) {
  * @param options.snapshotHTML Cached snapshot to render
  * @param options.response Response of the specified location
  */
-export function visit(location: Locatable, options?: Partial<VisitOptions>): Promise<void> {
-  return session.visit(location, options)
+export function visit(location: Locatable, options?: Partial<VisitOptions>) {
+  session.visit(location, options)
 }
 
 /**

--- a/src/core/native/adapter.ts
+++ b/src/core/native/adapter.ts
@@ -3,7 +3,7 @@ import { FormSubmission } from "../drive/form_submission"
 import { ReloadReason } from "./browser_adapter"
 
 export interface Adapter {
-  visitProposedToLocation(location: URL, options?: Partial<VisitOptions>): Promise<void>
+  visitProposedToLocation(location: URL, options?: Partial<VisitOptions>): void
   visitStarted(visit: Visit): void
   visitCompleted(visit: Visit): void
   visitFailed(visit: Visit): void

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -24,7 +24,7 @@ export class BrowserAdapter implements Adapter {
   }
 
   visitProposedToLocation(location: URL, options?: Partial<VisitOptions>) {
-    return this.navigator.startVisit(location, options?.restorationIdentifier || uuid(), options)
+    this.navigator.startVisit(location, options?.restorationIdentifier || uuid(), options)
   }
 
   visitStarted(visit: Visit) {

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,7 +1,11 @@
-import { ResolvingFunctions } from "./types"
 import { Bardo, BardoDelegate } from "./bardo"
 import { Snapshot } from "./snapshot"
 import { ReloadReason } from "./native/browser_adapter"
+
+type ResolvingFunctions<T = unknown> = {
+  resolve(value: T | PromiseLike<T>): void
+  reject(reason?: any): void
+}
 
 export type Render<E> = (newElement: E, currentElement: E) => void
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -195,16 +195,13 @@ export class Session
     const action = this.getActionForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
 
-    this.visit(location.href, { action, acceptsStreamResponse, initiator: link })
+    this.visit(location.href, { action, acceptsStreamResponse })
   }
 
   // Navigator delegate
 
-  allowsVisitingLocation(location: URL, options: Partial<VisitOptions> = {}) {
-    return (
-      this.locationWithActionIsSamePage(location, options.action) ||
-      this.applicationAllowsVisitingLocation(location, options)
-    )
+  allowsVisitingLocationWithAction(location: URL, action?: Action) {
+    return this.locationWithActionIsSamePage(location, action) || this.applicationAllowsVisitingLocation(location)
   }
 
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>) {
@@ -218,7 +215,7 @@ export class Session
     }
     extendURLWithDeprecatedProperties(visit.location)
     if (!visit.silent) {
-      this.notifyApplicationAfterVisitingLocation(visit.location, visit.action, visit.initiator)
+      this.notifyApplicationAfterVisitingLocation(visit.location, visit.action)
     }
   }
 
@@ -323,8 +320,8 @@ export class Session
     return !event.defaultPrevented
   }
 
-  applicationAllowsVisitingLocation(location: URL, options: Partial<VisitOptions> = {}) {
-    const event = this.notifyApplicationBeforeVisitingLocation(location, options.initiator)
+  applicationAllowsVisitingLocation(location: URL) {
+    const event = this.notifyApplicationBeforeVisitingLocation(location)
     return !event.defaultPrevented
   }
 
@@ -336,19 +333,15 @@ export class Session
     })
   }
 
-  notifyApplicationBeforeVisitingLocation(location: URL, element?: Element) {
+  notifyApplicationBeforeVisitingLocation(location: URL) {
     return dispatch<TurboBeforeVisitEvent>("turbo:before-visit", {
-      target: element,
       detail: { url: location.href },
       cancelable: true,
     })
   }
 
-  notifyApplicationAfterVisitingLocation(location: URL, action: Action, element?: Element) {
-    return dispatch<TurboVisitEvent>("turbo:visit", {
-      target: element,
-      detail: { url: location.href, action },
-    })
+  notifyApplicationAfterVisitingLocation(location: URL, action: Action) {
+    return dispatch<TurboVisitEvent>("turbo:visit", { detail: { url: location.href, action } })
   }
 
   notifyApplicationBeforeCachingSnapshot() {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -109,14 +109,14 @@ export class Session
     this.adapter = adapter
   }
 
-  visit(location: Locatable, options: Partial<VisitOptions> = {}): Promise<void> {
+  visit(location: Locatable, options: Partial<VisitOptions> = {}) {
     const frameElement = options.frame ? document.getElementById(options.frame) : null
 
     if (frameElement instanceof FrameElement) {
       frameElement.src = location.toString()
-      return frameElement.loaded
+      frameElement.loaded
     } else {
-      return this.navigator.proposeVisit(expandURL(location), options)
+      this.navigator.proposeVisit(expandURL(location), options)
     }
   }
 
@@ -206,7 +206,7 @@ export class Session
 
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>) {
     extendURLWithDeprecatedProperties(location)
-    return this.adapter.visitProposedToLocation(location, options)
+    this.adapter.visitProposedToLocation(location, options)
   }
 
   visitStarted(visit: Visit) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,8 +18,3 @@ export type StreamSource = {
     options?: boolean | EventListenerOptions
   ): void
 }
-
-export type ResolvingFunctions<T = unknown> = {
-  resolve(value: T | PromiseLike<T>): void
-  reject(reason?: any): void
-}

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -1,4 +1,5 @@
 import { FetchResponse } from "./fetch_response"
+import { FrameElement } from "../elements/frame_element"
 import { dispatch } from "../util"
 
 export type TurboBeforeFetchRequestEvent = CustomEvent<{
@@ -65,7 +66,7 @@ export class FetchRequest {
   readonly headers: FetchRequestHeaders
   readonly url: URL
   readonly body?: FetchRequestBody
-  readonly target?: Element | null
+  readonly target?: FrameElement | HTMLFormElement | null
   readonly abortController = new AbortController()
   private resolveRequestPromise = (_value: any) => {}
 
@@ -74,7 +75,7 @@ export class FetchRequest {
     method: FetchMethod,
     location: URL,
     body: FetchRequestBody = new URLSearchParams(),
-    target: Element | null = null
+    target: FrameElement | HTMLFormElement | null = null
   ) {
     this.delegate = delegate
     this.method = method

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -10,7 +10,6 @@ import {
   nextBody,
   nextEventNamed,
   noNextEventNamed,
-  nextEventOnTarget,
   pathname,
   readEventLogs,
   search,
@@ -389,16 +388,4 @@ test("test ignores links that target an iframe", async ({ page }) => {
   await nextBeat()
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-})
-
-test("test visit events are dispatched on the initiator", async ({ page }) => {
-  await page.click("#same-origin-unannotated-link")
-  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-visit")
-  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:visit")
-})
-
-test("test fetch events are dispatched on the initiator", async ({ page }) => {
-  await page.click("#same-origin-unannotated-link")
-  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-request")
-  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-response")
 })

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -40,38 +40,9 @@ test("test programmatically visiting a same-origin location", async ({ page }) =
   assert.ok(timing)
 })
 
-test("test programmatically Turbo.visit-ing a same-origin location", async ({ page }) => {
-  const urlBeforeVisit = page.url()
-  await page.evaluate(async () => await window.Turbo.visit("/src/tests/fixtures/one.html"))
-
-  const urlAfterVisit = page.url()
-  assert.notEqual(urlBeforeVisit, urlAfterVisit)
-  assert.equal(await visitAction(page), "advance")
-
-  const { url: urlFromBeforeVisitEvent } = await nextEventNamed(page, "turbo:before-visit")
-  assert.equal(urlFromBeforeVisitEvent, urlAfterVisit)
-
-  const { url: urlFromVisitEvent } = await nextEventNamed(page, "turbo:visit")
-  assert.equal(urlFromVisitEvent, urlAfterVisit)
-
-  const { timing } = await nextEventNamed(page, "turbo:load")
-  assert.ok(timing)
-})
-
 test("skip programmatically visiting a cross-origin location falls back to window.location", async ({ page }) => {
   const urlBeforeVisit = page.url()
   await visitLocation(page, "about:blank")
-
-  const urlAfterVisit = page.url()
-  assert.notEqual(urlBeforeVisit, urlAfterVisit)
-  assert.equal(await visitAction(page), "load")
-})
-
-test("skip programmatically Turbo.visit-ing a cross-origin location falls back to window.location", async ({
-  page,
-}) => {
-  const urlBeforeVisit = page.url()
-  await page.evaluate(async () => await window.Turbo.visit("about:blank"))
 
   const urlAfterVisit = page.url()
   assert.notEqual(urlBeforeVisit, urlAfterVisit)
@@ -105,28 +76,6 @@ test("test canceling a before-visit event prevents navigation", async ({ page })
 
   const urlAfterVisit = page.url()
   assert.equal(urlAfterVisit, urlBeforeVisit)
-})
-
-test("test canceling a before-visit event prevents a Turbo.visit-initiated navigation", async ({ page }) => {
-  await cancelNextVisit(page)
-  const urlBeforeVisit = page.url()
-
-  assert.notOk<boolean>(
-    await willChangeBody(page, async () => {
-      await page.evaluate(async () => {
-        try {
-          return await window.Turbo.visit("/src/tests/fixtures/one.html")
-        } catch {
-          const title = document.querySelector("h1")
-          if (title) title.innerHTML = "Visit canceled"
-        }
-      })
-    })
-  )
-
-  const urlAfterVisit = page.url()
-  assert.equal(urlAfterVisit, urlBeforeVisit)
-  assert.equal(await page.textContent("h1"), "Visit canceled")
 })
 
 test("test navigation by history is not cancelable", async ({ page }) => {

--- a/src/tests/unit/deprecated_adapter_support_test.ts
+++ b/src/tests/unit/deprecated_adapter_support_test.ts
@@ -34,10 +34,8 @@ export class DeprecatedAdapterSupportTest extends DOMTestCase implements Adapter
 
   // Adapter interface
 
-  visitProposedToLocation(location: URL, _options?: Partial<VisitOptions>): Promise<void> {
+  visitProposedToLocation(location: URL, _options?: Partial<VisitOptions>): void {
     this.locations.push(location)
-
-    return Promise.resolve()
   }
 
   visitStarted(visit: Visit): void {


### PR DESCRIPTION
Since #650, errors are present in the console whenever initiating a visit causes cancellation of the previous visit.

Reported in:
- https://github.com/hotwired/turbo/issues/706
- https://github.com/hotwired/turbo/issues/716

Reverting until a solution is found for the errors.

This reverts commit aeeaae8edb5f6ec6ef6b19eaf93dc060a1e67b10.